### PR TITLE
use python-dateutils parser

### DIFF
--- a/bot/func.py
+++ b/bot/func.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from dateutil.parser import parse
 from telegram import ReplyKeyboardMarkup, KeyboardButton, ParseMode
 
 import strings
@@ -36,9 +37,9 @@ def remindme(bot, update, args, job_queue, chat_data): # Remind setter
 
     today = datetime.now()
     try:
-        args = f'{args[0]} {args[1]} {args[2]}, {args[3]}' #format received date
+        args = "".join(args)
 
-        args = datetime.strptime(args, '%Y %b %d, %H:%M:%S')
+        args = parse(args)
         delta = (args - today).total_seconds()
         print(args)
         print(today)


### PR DESCRIPTION
Hello! It sounds like in #1, you're looking for the [python-dateutil](https://labix.org/python-dateutil#head-a23e8ae0a661d77b89dfb3476f85b26f0b30349c) library. Its `parse` function handles several date/time formats. This means you could type "Wed" for the next Wednesday available, "28" for the 28th of the current month, and several other shorthand date representations.

Please note:
  - This code hasn't been tested: I couldn't recreate the environment the bot runs in for testing, as I haven't worked with Heroku or Telegram bots before.
  - You'll need to install `python-dateutil` through `pip`.

